### PR TITLE
Adds color support for Windows 11 + typo fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To include `adb` and other android tools on your path on OS X / Linux:
 
 Include these lines in your `.bashrc` or `.zshrc`.
 
-On Widnows add `<path to Android SDK>/platform-tools` and `<path to Android SDK>/tools` to your PATH in [System Properties](https://support.microsoft.com/en-sg/help/310519/how-to-manage-environment-variables-in-windows-xp)
+On Windows add `<path to Android SDK>/platform-tools` and `<path to Android SDK>/tools` to your PATH in [System Properties](https://support.microsoft.com/en-sg/help/310519/how-to-manage-environment-variables-in-windows-xp)
 
 *Note:* `<path to Android SDK>` should be absolute and not relative.
 

--- a/pidcat.py
+++ b/pidcat.py
@@ -32,7 +32,7 @@ from platform import win32_ver
 __version__ = '2.1.0+Win10'
 
 win_ver = win32_ver()[0]
-show_colors = (win_ver == '10' or win_ver == '') and sys.stdout.isatty()
+show_colors = (win_ver == '10' or win_ver == '11' or win_ver == '') and sys.stdout.isatty()
 
 LOG_LEVELS = 'VDIWEF'
 LOG_LEVELS_MAP = dict([(LOG_LEVELS[i], i) for i in range(len(LOG_LEVELS))])


### PR DESCRIPTION
Simply adds the version of Windows 11 to the color compatibility check and also fixes a typo in the README.